### PR TITLE
fix for bug #69076 (URL parsing throws exception on empty query string)

### DIFF
--- a/php_http_url.c
+++ b/php_http_url.c
@@ -1271,7 +1271,7 @@ static const char *parse_query(struct parse_state *state)
 	tmp = ++state->ptr;
 	state->url.query = &state->buffer[state->offset];
 
-	do {
+	while(state->ptr < state->end) {
 		switch (*state->ptr) {
 		case '#':
 			goto done;
@@ -1323,7 +1323,9 @@ static const char *parse_query(struct parse_state *state)
 			}
 			state->ptr += mb - 1;
 		}
-	} while (++state->ptr < state->end);
+
+		++state->ptr;
+	}
 
 	done:
 	state->buffer[state->offset++] = 0;

--- a/tests/bug69076.phpt
+++ b/tests/bug69076.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Bug #69076 (URL parsing throws exception on empty query string)
+--SKIPIF--
+<?php 
+include "skipif.inc";
+?>
+--FILE--
+<?php 
+echo "Test\n";
+echo new http\Url("http://foo.bar/?");
+?>
+
+===DONE===
+--EXPECT--
+Test
+http://foo.bar/
+===DONE===


### PR DESCRIPTION
Any class that parses a URL will throw an exception when a URL with an empty query string (e.g. "http://www.example.com/?") is passed in. This should be handled in the same way as if there was no query string.

URLs with a '?' as the last character (i.e. empty query string) were not being correctly handled, resulting in an exception: Failed to parse query; unexpected byte 0x00 at pos 0 in ''
