### PR TITLE
Fix removal of ZVAL_FAST macros

### DIFF
--- a/php_http_client.c
+++ b/php_http_client.c
@@ -148,7 +148,7 @@ void php_http_client_options_get_subr(zval *instance, char *key, size_t len, zva
 	zval *options, opts_tmp, *opts = zend_read_property(this_ce, instance, ZEND_STRL("options"), 0, &opts_tmp);
 
 	if ((Z_TYPE_P(opts) == IS_ARRAY) && (options = zend_symtable_str_find(Z_ARRVAL_P(opts), key, len))) {
-		RETVAL_ZVAL_FAST(options);
+		RETVAL_ZVAL(options, 1, 0);
 	}
 }
 
@@ -537,7 +537,7 @@ static PHP_METHOD(HttpClient, reset)
 	obj->iterator = 0;
 	php_http_client_reset(obj->client);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 static HashTable *combined_options(zval *client, zval *request)
@@ -630,7 +630,7 @@ static PHP_METHOD(HttpClient, enqueue)
 			return;
 	);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_dequeue, 0, 0, 1)
@@ -654,7 +654,7 @@ static PHP_METHOD(HttpClient, dequeue)
 
 	php_http_expect(SUCCESS == php_http_client_dequeue(obj->client, msg_obj->message), runtime, return);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_requeue, 0, 0, 1)
@@ -700,7 +700,7 @@ static PHP_METHOD(HttpClient, requeue)
 			return;
 	);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_count, 0, 0, 0)
@@ -767,7 +767,7 @@ static PHP_METHOD(HttpClient, getHistory)
 	php_http_expect(SUCCESS == zend_parse_parameters_none(), invalid_arg, return);
 
 	zhistory = zend_read_property(php_http_client_class_entry, getThis(), ZEND_STRL("history"), 0, &zhistory_tmp);
-	RETVAL_ZVAL_FAST(zhistory);
+	RETVAL_ZVAL(zhistory, 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_send, 0, 0, 0)
@@ -782,7 +782,7 @@ static PHP_METHOD(HttpClient, send)
 
 	php_http_expect(SUCCESS == php_http_client_exec(obj->client), runtime, return);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_once, 0, 0, 0)
@@ -844,7 +844,7 @@ static PHP_METHOD(HttpClient, enablePipelining)
 
 	php_http_expect(SUCCESS == php_http_client_setopt(obj->client, PHP_HTTP_CLIENT_OPT_ENABLE_PIPELINING, &enable), unexpected_val, return);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_enableEvents, 0, 0, 0)
@@ -861,7 +861,7 @@ static PHP_METHOD(HttpClient, enableEvents)
 
 	php_http_expect(SUCCESS == php_http_client_setopt(obj->client, PHP_HTTP_CLIENT_OPT_USE_EVENTS, &enable), unexpected_val, return);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 struct notify_arg {
@@ -927,7 +927,7 @@ static PHP_METHOD(HttpClient, notify)
 		}
 	}
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_attach, 0, 0, 1)
@@ -956,7 +956,7 @@ static PHP_METHOD(HttpClient, attach)
 	zend_call_method_with_1_params(observers, NULL, NULL, "attach", &retval, observer);
 	zval_ptr_dtor(&retval);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_detach, 0, 0, 1)
@@ -979,7 +979,7 @@ static PHP_METHOD(HttpClient, detach)
 	zend_call_method_with_1_params(observers, NULL, NULL, "detach", &retval, observer);
 	zval_ptr_dtor(&retval);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_getObservers, 0, 0, 0)
@@ -997,7 +997,7 @@ static PHP_METHOD(HttpClient, getObservers)
 		return;
 	}
 
-	RETVAL_ZVAL_FAST(observers);
+	RETVAL_ZVAL(observers, 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_getProgressInfo, 0, 0, 1)
@@ -1058,7 +1058,7 @@ static PHP_METHOD(HttpClient, setOptions)
 
 	php_http_client_options_set(getThis(), opts);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_getOptions, 0, 0, 0)
@@ -1067,7 +1067,7 @@ static PHP_METHOD(HttpClient, getOptions)
 {
 	if (SUCCESS == zend_parse_parameters_none()) {
 		zval options_tmp, *options = zend_read_property(php_http_client_class_entry, getThis(), ZEND_STRL("options"), 0, &options_tmp);
-		RETVAL_ZVAL_FAST(options);
+		RETVAL_ZVAL(options, 1, 0);
 	}
 }
 
@@ -1082,7 +1082,7 @@ static PHP_METHOD(HttpClient, setSslOptions)
 
 	php_http_client_options_set_subr(getThis(), ZEND_STRL("ssl"), opts, 1);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_addSslOptions, 0, 0, 0)
@@ -1096,7 +1096,7 @@ static PHP_METHOD(HttpClient, addSslOptions)
 
 	php_http_client_options_set_subr(getThis(), ZEND_STRL("ssl"), opts, 0);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_getSslOptions, 0, 0, 0)
@@ -1119,7 +1119,7 @@ static PHP_METHOD(HttpClient, setCookies)
 
 	php_http_client_options_set_subr(getThis(), ZEND_STRL("cookies"), opts, 1);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_addCookies, 0, 0, 0)
@@ -1133,7 +1133,7 @@ static PHP_METHOD(HttpClient, addCookies)
 
 	php_http_client_options_set_subr(getThis(), ZEND_STRL("cookies"), opts, 0);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClient_getCookies, 0, 0, 0)

--- a/php_http_client_request.c
+++ b/php_http_client_request.c
@@ -82,7 +82,7 @@ static PHP_METHOD(HttpClientRequest, setContentType)
 	ZVAL_STR_COPY(&zct, ct_str);
 	zend_hash_str_update(&obj->message->hdrs, "Content-Type", lenof("Content-Type"), &zct);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClientRequest_getContentType, 0, 0, 0)
@@ -98,7 +98,7 @@ static PHP_METHOD(HttpClientRequest, getContentType)
 		php_http_message_update_headers(obj->message);
 		zct = php_http_message_header(obj->message, ZEND_STRL("Content-Type"));
 		if (zct) {
-			RETURN_ZVAL_FAST(zct);
+			RETURN_ZVAL(zct, 1, 0);
 		}
 	}
 }
@@ -144,7 +144,7 @@ static PHP_METHOD(HttpClientRequest, setQuery)
 	}
 	zval_ptr_dtor(&str);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClientRequest_getQuery, 0, 0, 0)
@@ -197,7 +197,7 @@ static PHP_METHOD(HttpClientRequest, addQuery)
 	}
 	zval_ptr_dtor(&str);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClientRequest_setOptions, 0, 0, 0)
@@ -211,7 +211,7 @@ static PHP_METHOD(HttpClientRequest, setOptions)
 
 	php_http_client_options_set(getThis(), opts);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClientRequest_getOptions, 0, 0, 0)
@@ -220,7 +220,7 @@ static PHP_METHOD(HttpClientRequest, getOptions)
 {
 	if (SUCCESS == zend_parse_parameters_none()) {
 		zval tmp, *zoptions = zend_read_property(php_http_client_request_class_entry, getThis(), ZEND_STRL("options"), 0, &tmp);
-		RETURN_ZVAL_FAST(zoptions);
+		RETURN_ZVAL(zoptions, 1, 0);
 	}
 }
 
@@ -235,7 +235,7 @@ static PHP_METHOD(HttpClientRequest, setSslOptions)
 
 	php_http_client_options_set_subr(getThis(), ZEND_STRL("ssl"), opts, 1);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClientRequest_addSslOptions, 0, 0, 0)
@@ -249,7 +249,7 @@ static PHP_METHOD(HttpClientRequest, addSslOptions)
 
 	php_http_client_options_set_subr(getThis(), ZEND_STRL("ssl"), opts, 0);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpClientRequest_getSslOptions, 0, 0, 0)

--- a/php_http_client_response.c
+++ b/php_http_client_response.c
@@ -112,7 +112,7 @@ static PHP_METHOD(HttpClientResponse, getTransferInfo)
 		}
 	}
 
-	RETURN_ZVAL_FAST(info);
+	RETURN_ZVAL(info, 1, 0);
 }
 
 static zend_function_entry php_http_client_response_methods[] = {

--- a/php_http_cookie.c
+++ b/php_http_cookie.c
@@ -532,7 +532,7 @@ static PHP_METHOD(HttpCookie, setCookies)
 		array_copy_strings(cookies, &obj->list->cookies);
 	}
 
-	RETURN_ZVAL_FAST(getThis());
+	RETURN_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_addCookies, 0, 0, 1)
@@ -551,7 +551,7 @@ static PHP_METHOD(HttpCookie, addCookies)
 
 	array_join(cookies, &obj->list->cookies, 1, ARRAY_JOIN_STRONLY|ARRAY_JOIN_STRINGIFY);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_getExtras, 0, 0, 0)
@@ -591,7 +591,7 @@ static PHP_METHOD(HttpCookie, setExtras)
 		array_copy_strings(extras, &obj->list->extras);
 	}
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_addExtras, 0, 0, 1)
@@ -610,7 +610,7 @@ static PHP_METHOD(HttpCookie, addExtras)
 
 	array_join(extras, &obj->list->extras, 1, ARRAY_JOIN_STRONLY|ARRAY_JOIN_STRINGIFY);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_getCookie, 0, 0, 1)
@@ -632,7 +632,7 @@ static PHP_METHOD(HttpCookie, getCookie)
 	PHP_HTTP_COOKIE_OBJECT_INIT(obj);
 
 	if (php_http_cookie_list_get_cookie(obj->list, name_str, name_len, &zvalue)) {
-		RETURN_ZVAL_FAST(&zvalue);
+		RETURN_ZVAL(&zvalue, 1, 0);
 	}
 }
 
@@ -658,7 +658,7 @@ static PHP_METHOD(HttpCookie, setCookie)
 		php_http_cookie_list_add_cookie(obj->list, name_str, name_len, value_str, value_len);
 	}
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_addCookie, 0, 0, 2)
@@ -679,7 +679,7 @@ static PHP_METHOD(HttpCookie, addCookie)
 
 	php_http_cookie_list_add_cookie(obj->list, name_str, name_len, value_str, value_len);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_getExtra, 0, 0, 1)
@@ -701,7 +701,7 @@ static PHP_METHOD(HttpCookie, getExtra)
 	PHP_HTTP_COOKIE_OBJECT_INIT(obj);
 
 	if (php_http_cookie_list_get_extra(obj->list, name_str, name_len, &zvalue)) {
-		RETURN_ZVAL_FAST(&zvalue);
+		RETURN_ZVAL(&zvalue, 1, 0);
 	}
 }
 
@@ -727,7 +727,7 @@ static PHP_METHOD(HttpCookie, setExtra)
 		php_http_cookie_list_add_extra(obj->list, name_str, name_len, value_str, value_len);
 	}
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_addExtra, 0, 0, 2)
@@ -748,7 +748,7 @@ static PHP_METHOD(HttpCookie, addExtra)
 
 	php_http_cookie_list_add_extra(obj->list, name_str, name_len, value_str, value_len);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_getDomain, 0, 0, 0)
@@ -787,7 +787,7 @@ static PHP_METHOD(HttpCookie, setDomain)
 
 	PTR_SET(obj->list->domain, domain_str ? estrndup(domain_str, domain_len) : NULL);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_getPath, 0, 0, 0)
@@ -826,7 +826,7 @@ static PHP_METHOD(HttpCookie, setPath)
 
 	PTR_SET(obj->list->path, path_str ? estrndup(path_str, path_len) : NULL);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_getExpires, 0, 0, 0)
@@ -862,7 +862,7 @@ static PHP_METHOD(HttpCookie, setExpires)
 
 	obj->list->expires = ts;
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_getMaxAge, 0, 0, 0)
@@ -898,7 +898,7 @@ static PHP_METHOD(HttpCookie, setMaxAge)
 
 	obj->list->max_age = ma;
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_getFlags, 0, 0, 0)
@@ -934,7 +934,7 @@ static PHP_METHOD(HttpCookie, setFlags)
 
 	obj->list->flags = flags;
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpCookie_toString, 0, 0, 0)

--- a/php_http_env_request.c
+++ b/php_http_env_request.c
@@ -192,7 +192,7 @@ static PHP_METHOD(HttpEnvRequest, getForm)
 		call_querystring_get("form");
 	} else {
 		zval zform_tmp, *zform = zend_read_property(php_http_env_request_class_entry, getThis(), ZEND_STRL("form"), 0, &zform_tmp);
-		RETURN_ZVAL_FAST(zform);
+		RETURN_ZVAL(zform, 1, 0);
 	}
 }
 
@@ -208,7 +208,7 @@ static PHP_METHOD(HttpEnvRequest, getQuery)
 		call_querystring_get("query");
 	} else {
 		zval zquery_tmp, *zquery = zend_read_property(php_http_env_request_class_entry, getThis(), ZEND_STRL("query"), 0, &zquery_tmp);
-		RETURN_ZVAL_FAST(zquery);
+		RETURN_ZVAL(zquery, 1, 0);
 	}
 }
 
@@ -224,7 +224,7 @@ static PHP_METHOD(HttpEnvRequest, getCookie)
 		call_querystring_get("cookie");
 	} else {
 		zval zcookie_tmp, *zcookie = zend_read_property(php_http_env_request_class_entry, getThis(), ZEND_STRL("cookie"), 0, &zcookie_tmp);
-		RETURN_ZVAL_FAST(zcookie);
+		RETURN_ZVAL(zcookie, 1, 0);
 	}
 }
 
@@ -234,7 +234,7 @@ static PHP_METHOD(HttpEnvRequest, getFiles)
 {
 	if (SUCCESS == zend_parse_parameters_none()) {
 		zval zfiles_tmp, *zfiles = zend_read_property(php_http_env_request_class_entry, getThis(), ZEND_STRL("files"), 0, &zfiles_tmp);
-		RETURN_ZVAL_FAST(zfiles);
+		RETURN_ZVAL(zfiles, 1, 0);
 	}
 }
 

--- a/php_http_env_response.c
+++ b/php_http_env_response.c
@@ -1172,7 +1172,7 @@ static PHP_METHOD(HttpEnvResponse, setEnvRequest)
 	php_http_expect(SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "|O", &env_req, php_http_message_class_entry), invalid_arg, return);
 
 	set_option(getThis(), ZEND_STRL("request"), IS_OBJECT, env_req, 0);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_setContentType, 0, 0, 1)
@@ -1186,7 +1186,7 @@ static PHP_METHOD(HttpEnvResponse, setContentType)
 	php_http_expect(SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &ct_str, &ct_len), invalid_arg, return);
 
 	set_option(getThis(), ZEND_STRL("contentType"), IS_STRING, ct_str, ct_len);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_setContentDisposition, 0, 0, 1)
@@ -1199,7 +1199,7 @@ static PHP_METHOD(HttpEnvResponse, setContentDisposition)
 	php_http_expect(SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "a", &zdisposition), invalid_arg, return);
 
 	zend_update_property(Z_OBJCE_P(getThis()), getThis(), ZEND_STRL("contentDisposition"), zdisposition);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_setContentEncoding, 0, 0, 1)
@@ -1212,7 +1212,7 @@ static PHP_METHOD(HttpEnvResponse, setContentEncoding)
 	php_http_expect(SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "l", &ce), invalid_arg, return);
 
 	set_option(getThis(), ZEND_STRL("contentEncoding"), IS_LONG, &ce, 0);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_setCacheControl, 0, 0, 1)
@@ -1226,7 +1226,7 @@ static PHP_METHOD(HttpEnvResponse, setCacheControl)
 	php_http_expect(SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &cc_str, &cc_len), invalid_arg, return);
 
 	set_option(getThis(), ZEND_STRL("cacheControl"), IS_STRING, cc_str, cc_len);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_setLastModified, 0, 0, 1)
@@ -1239,7 +1239,7 @@ static PHP_METHOD(HttpEnvResponse, setLastModified)
 	php_http_expect(SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "l", &last_modified), invalid_arg, return);
 
 	set_option(getThis(), ZEND_STRL("lastModified"), IS_LONG, &last_modified, 0);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_isCachedByLastModified, 0, 0, 0)
@@ -1271,7 +1271,7 @@ static PHP_METHOD(HttpEnvResponse, setEtag)
 	php_http_expect(SUCCESS == zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &etag_str, &etag_len), invalid_arg, return);
 
 	set_option(getThis(), ZEND_STRL("etag"), IS_STRING, etag_str, etag_len);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_isCachedByEtag, 0, 0, 0)
@@ -1304,7 +1304,7 @@ static PHP_METHOD(HttpEnvResponse, setThrottleRate)
 
 	set_option(getThis(), ZEND_STRL("throttleDelay"), IS_DOUBLE, &delay, 0);
 	set_option(getThis(), ZEND_STRL("throttleChunk"), IS_LONG, &chunk_size, 0);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_setCookie, 0, 0, 1)
@@ -1345,7 +1345,7 @@ static PHP_METHOD(HttpEnvResponse, setCookie)
 	set_cookie(getThis(), zcookie_new);
 	zval_ptr_dtor(zcookie_new);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpEnvResponse_send, 0, 0, 0)

--- a/php_http_message.c
+++ b/php_http_message.c
@@ -694,7 +694,7 @@ void php_http_message_object_reverse(zval *zmsg, zval *return_value)
 
 		efree(objects);
 	} else {
-		RETURN_ZVAL_FAST(zmsg);
+		RETURN_ZVAL(zmsg, 1, 0);
 	}
 }
 
@@ -1071,7 +1071,7 @@ static PHP_METHOD(HttpMessage, setBody)
 		PHP_HTTP_MESSAGE_OBJECT_INIT(obj);
 		php_http_message_object_prophandler_set_body(obj, zbody);
 	}
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_addBody, 0, 0, 1)
@@ -1088,7 +1088,7 @@ static PHP_METHOD(HttpMessage, addBody)
 		PHP_HTTP_MESSAGE_OBJECT_INIT(obj);
 		php_http_message_body_to_callback(new_obj->body, (php_http_pass_callback_t) php_http_message_body_append, obj->message->body, 0, 0);
 	}
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getHeader, 0, 0, 1)
@@ -1109,7 +1109,7 @@ static PHP_METHOD(HttpMessage, getHeader)
 
 		if ((header = php_http_message_header(obj->message, header_str, header_len))) {
 			if (!header_ce) {
-				RETURN_ZVAL_FAST(header);
+				RETURN_ZVAL(header, 1, 0);
 			} else if (instanceof_function(header_ce, php_http_header_class_entry)) {
 				php_http_object_method_t cb;
 				zval argv[2];
@@ -1172,7 +1172,7 @@ static PHP_METHOD(HttpMessage, setHeader)
 		}
 		efree(name);
 	}
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_setHeaders, 0, 0, 1)
@@ -1192,7 +1192,7 @@ static PHP_METHOD(HttpMessage, setHeaders)
 			array_join(Z_ARRVAL_P(new_headers), &obj->message->hdrs, 0, ARRAY_JOIN_PRETTIFY|ARRAY_JOIN_STRONLY);
 		}
 	}
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_addHeader, 0, 0, 2)
@@ -1221,7 +1221,7 @@ static PHP_METHOD(HttpMessage, addHeader)
 		}
 		efree(name);
 	}
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_addHeaders, 0, 0, 1)
@@ -1240,7 +1240,7 @@ static PHP_METHOD(HttpMessage, addHeaders)
 
 		array_join(Z_ARRVAL_P(new_headers), &obj->message->hdrs, append, ARRAY_JOIN_STRONLY|ARRAY_JOIN_PRETTIFY);
 	}
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getType, 0, 0, 0)
@@ -1270,7 +1270,7 @@ static PHP_METHOD(HttpMessage, setType)
 
 		php_http_message_set_type(obj->message, type);
 	}
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getInfo, 0, 0, 0)
@@ -1325,7 +1325,7 @@ static PHP_METHOD(HttpMessage, setInfo)
 	php_http_message_set_info(obj->message, &inf);
 	php_http_info_dtor(&inf);
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getHttpVersion, 0, 0, 0)
@@ -1363,7 +1363,7 @@ static PHP_METHOD(HttpMessage, setHttpVersion)
 
 	obj->message->http.version = version;
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getResponseCode, 0, 0, 0)
@@ -1412,7 +1412,7 @@ static PHP_METHOD(HttpMessage, setResponseCode)
 	obj->message->http.info.response.code = code;
 	PTR_SET(obj->message->http.info.response.status, estrdup(php_http_env_get_response_status_for_code(code)));
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getResponseStatus, 0, 0, 0)
@@ -1456,7 +1456,7 @@ static PHP_METHOD(HttpMessage, setResponseStatus)
 	}
 
 	PTR_SET(obj->message->http.info.response.status, estrndup(status, status_len));
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getRequestMethod, 0, 0, 0)
@@ -1507,7 +1507,7 @@ static PHP_METHOD(HttpMessage, setRequestMethod)
 	}
 
 	PTR_SET(obj->message->http.info.request.method, estrndup(method, method_len));
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getRequestUrl, 0, 0, 0)
@@ -1568,7 +1568,7 @@ static PHP_METHOD(HttpMessage, setRequestUrl)
 		PTR_SET(obj->message->http.info.request.url, url);
 	}
 
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_getParentMessage, 0, 0, 0)
@@ -1653,7 +1653,7 @@ static PHP_METHOD(HttpMessage, toCallback)
 		zend_fcall_info_args_clear(&fcd.fci, 1);
 		zval_ptr_dtor(&fcd.fcz);
 
-		RETURN_ZVAL_FAST(getThis());
+		RETURN_ZVAL(getThis(), 1, 0);
 	}
 }
 
@@ -1747,7 +1747,7 @@ static PHP_METHOD(HttpMessage, prepend)
 	}
 
 	php_http_message_object_prepend(getThis(), prepend, top);
-	RETURN_ZVAL_FAST(getThis());
+	RETURN_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessage_reverse, 0, 0, 0)
@@ -1895,7 +1895,7 @@ static PHP_METHOD(HttpMessage, current)
 		php_http_message_object_t *obj = PHP_HTTP_OBJ(NULL, getThis());
 
 		if (!Z_ISUNDEF(obj->iterator)) {
-			RETURN_ZVAL_FAST(&obj->iterator);
+			RETURN_ZVAL(&obj->iterator, 1, 0);
 		}
 	}
 }

--- a/php_http_message_body.c
+++ b/php_http_message_body.c
@@ -694,7 +694,7 @@ PHP_METHOD(HttpMessageBody, toCallback)
 		php_http_message_body_to_callback(obj->body, php_http_pass_fcall_callback, &fcd, offset, forlen);
 		zend_fcall_info_args_clear(&fcd.fci, 1);
 		zval_ptr_dtor(&fcd.fcz);
-		RETURN_ZVAL_FAST(getThis());
+		RETURN_ZVAL(getThis(), 1, 0);
 	}
 }
 
@@ -743,7 +743,7 @@ PHP_METHOD(HttpMessageBody, append)
 
 	php_http_expect(len == php_http_message_body_append(obj->body, str, len), runtime, return);
 
-	RETURN_ZVAL_FAST(getThis());
+	RETURN_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessageBody_addForm, 0, 0, 0)
@@ -762,7 +762,7 @@ PHP_METHOD(HttpMessageBody, addForm)
 
 	php_http_expect(SUCCESS == php_http_message_body_add_form(obj->body, fields, files), runtime, return);
 
-	RETURN_ZVAL_FAST(getThis());
+	RETURN_ZVAL(getThis(), 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpMessageBody_addPart, 0, 0, 1)
@@ -787,7 +787,7 @@ PHP_METHOD(HttpMessageBody, addPart)
 	zend_restore_error_handling(&zeh);
 
 	if (!EG(exception)) {
-		RETURN_ZVAL_FAST(getThis());
+		RETURN_ZVAL(getThis(), 1, 0);
 	}
 }
 

--- a/php_http_negotiate.h
+++ b/php_http_negotiate.h
@@ -77,7 +77,7 @@ static inline HashTable *php_http_negotiate_content_type(HashTable *supported, p
 		 \
 		zend_hash_internal_pointer_reset((supported)); \
 		if ((value = zend_hash_get_current_data((supported)))) { \
-			RETVAL_ZVAL_FAST(value); \
+			RETVAL_ZVAL(value, 1, 0); \
 		} else { \
 			RETVAL_NULL(); \
 		} \

--- a/php_http_params.c
+++ b/php_http_params.c
@@ -1010,7 +1010,7 @@ PHP_METHOD(HttpParams, toArray)
 		return;
 	}
 	zparams = zend_read_property(php_http_params_class_entry, getThis(), ZEND_STRL("params"), 0, &zparams_tmp);
-	RETURN_ZVAL_FAST(zparams);
+	RETURN_ZVAL(zparams, 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpParams_toString, 0, 0, 0)
@@ -1092,7 +1092,7 @@ PHP_METHOD(HttpParams, offsetGet)
 	zparams = zend_read_property(php_http_params_class_entry, getThis(), ZEND_STRL("params"), 0, &zparams_tmp);
 
 	if (Z_TYPE_P(zparams) == IS_ARRAY && (zparam = zend_symtable_find(Z_ARRVAL_P(zparams), name))) {
-		RETVAL_ZVAL_FAST(zparam);
+		RETVAL_ZVAL(zparam, 1, 0);
 	}
 }
 

--- a/php_http_querystring.c
+++ b/php_http_querystring.c
@@ -67,7 +67,7 @@ static inline void php_http_querystring_get(zval *instance, int type, char *name
 			convert_to_explicit_type(&tmp, type);
 			RETVAL_ZVAL(&tmp, 0, 0);
 		} else {
-			RETVAL_ZVAL_FAST(arrval);
+			RETVAL_ZVAL(arrval, 1, 0);
 		}
 
 		if (del) {
@@ -79,7 +79,7 @@ static inline void php_http_querystring_get(zval *instance, int type, char *name
 			zval_ptr_dtor(&delarr);
 		}
 	} else if(defval) {
-		RETURN_ZVAL_FAST(defval);
+		RETURN_ZVAL(defval, 1, 0);
 	}
 }
 
@@ -350,7 +350,7 @@ PHP_METHOD(HttpQueryString, getGlobalInstance)
 	zend_string_release(zs);
 
 	if (Z_TYPE_P(instance) == IS_OBJECT) {
-		RETVAL_ZVAL_FAST(instance);
+		RETVAL_ZVAL(instance, 1, 0);
 	} else if ((_GET = php_http_env_get_superglobal(ZEND_STRL("_GET")))) {
 		ZVAL_OBJ(return_value, php_http_querystring_object_new(php_http_querystring_class_entry));
 
@@ -399,7 +399,7 @@ PHP_METHOD(HttpQueryString, toArray)
 	}
 
 	zqa = zend_read_property(php_http_querystring_class_entry, getThis(), ZEND_STRL("queryArray"), 0, &zqa_tmp);
-	RETURN_ZVAL_FAST(zqa);
+	RETURN_ZVAL(zqa, 1, 0);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(ai_HttpQueryString_get, 0, 0, 0)
@@ -529,7 +529,7 @@ PHP_METHOD(HttpQueryString, xlate)
 	);
 
 	php_http_querystring_set(getThis(), &na, 0);
-	RETVAL_ZVAL_FAST(getThis());
+	RETVAL_ZVAL(getThis(), 1, 0);
 	
 	zval_ptr_dtor(&na);
 }
@@ -580,7 +580,7 @@ PHP_METHOD(HttpQueryString, offsetGet)
 
 	if (Z_TYPE_P(qa) == IS_ARRAY) {
 		if ((value = zend_symtable_find(Z_ARRVAL_P(qa), offset))) {
-			RETVAL_ZVAL_FAST(value);
+			RETVAL_ZVAL(value, 1, 0);
 		}
 	}
 }


### PR DESCRIPTION
See this discussion:
https://github.com/php/php-src/commit/8e10e8f921101e0787c8228d257107a204de3e36#commitcomment-11843858

I fixed the compile errors and ran the tests. Because of the numerous errors I did the same with PHP 5.6.11RC1. Those tests are still running, but they are the same (at first sight).

This is my pecl http config:
https://phpdev.toolsforresearch.com/php-7.0.0alpha2-nts-Win32-VC14-x86.htm
With curl 7.43.0, Zlib 1.2.8 and libevent 2.1.5-beta. 

```
=====================================================================
Number of tests :  174               169
Tests skipped   :    5 (  2.9%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :   35 ( 20.1%) ( 20.7%)
Expected fail   :    1 (  0.6%) (  0.6%)
Tests passed    :  133 ( 76.4%) ( 78.7%)
---------------------------------------------------------------------
Time taken      : 1979 seconds
=====================================================================

=====================================================================
EXPECTED FAILED TEST SUMMARY
---------------------------------------------------------------------
property proxy [/php-sdk/php70dev/ext/http/tests/propertyproxy001.phpt]  XFAIL REASON: TBD
=====================================================================

=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Bug #66388 (Crash on POST with Content-Length:0 and untouched body) [/php-sdk/php70dev/ext/http/tests/bug66388.phpt]
client observer [/php-sdk/php70dev/ext/http/tests/client002.phpt]
client once & wait [/php-sdk/php70dev/ext/http/tests/client003.phpt]
client reset [/php-sdk/php70dev/ext/http/tests/client004.phpt]
client response callback [/php-sdk/php70dev/ext/http/tests/client005.phpt]
client response callback + dequeue [/php-sdk/php70dev/ext/http/tests/client006.phpt]
client response callback + requeue [/php-sdk/php70dev/ext/http/tests/client007.phpt]
client features [/php-sdk/php70dev/ext/http/tests/client008.phpt]
client static cookies [/php-sdk/php70dev/ext/http/tests/client009.phpt]
client upload [/php-sdk/php70dev/ext/http/tests/client010.phpt]
client history [/php-sdk/php70dev/ext/http/tests/client011.phpt]
client ssl [/php-sdk/php70dev/ext/http/tests/client012.phpt]
client observers [/php-sdk/php70dev/ext/http/tests/client013.phpt]
reset content length when resetting body [/php-sdk/php70dev/ext/http/tests/client014.phpt]
http client event base [/php-sdk/php70dev/ext/http/tests/client015.phpt]
client once & wait with events [/php-sdk/php70dev/ext/http/tests/client016.phpt]
client request gzip [/php-sdk/php70dev/ext/http/tests/client017.phpt]
client pipelining [/php-sdk/php70dev/ext/http/tests/client018.phpt]
client proxy - send proxy headers for a proxy request [/php-sdk/php70dev/ext/http/tests/client019.phpt]
client proxy - don't send proxy headers for a standard request [/php-sdk/php70dev/ext/http/tests/client020.phpt]
client cookies [/php-sdk/php70dev/ext/http/tests/client021.phpt]
client seek [/php-sdk/php70dev/ext/http/tests/client025.phpt]
client stream 128M [/php-sdk/php70dev/ext/http/tests/client026.phpt]
client response cookie [/php-sdk/php70dev/ext/http/tests/clientresponse001.phpt]
client response cookies [/php-sdk/php70dev/ext/http/tests/clientresponse002.phpt]
client response transfer info [/php-sdk/php70dev/ext/http/tests/clientresponse003.phpt]
etags with hash [/php-sdk/php70dev/ext/http/tests/etag001.phpt]
chunked filter [/php-sdk/php70dev/ext/http/tests/filterchunked.phpt]
zlib filter [/php-sdk/php70dev/ext/http/tests/filterzlib.phpt]
header parser with nonblocking stream [/php-sdk/php70dev/ext/http/tests/headerparser003.phpt]
invalid HTTP info [/php-sdk/php70dev/ext/http/tests/info001.phpt]
invalid HTTP info [/php-sdk/php70dev/ext/http/tests/info002.phpt]
env request message [/php-sdk/php70dev/ext/http/tests/message002.phpt]
message body append error [/php-sdk/php70dev/ext/http/tests/messagebody003.phpt]
message parser with nonblocking stream [/php-sdk/php70dev/ext/http/tests/messageparser002.phpt]
=====================================================================
```
